### PR TITLE
added --tunnel-through-iap to ssh and scp commands

### DIFF
--- a/docs/google-cloud/Running_Automator_part0.md
+++ b/docs/google-cloud/Running_Automator_part0.md
@@ -47,7 +47,7 @@ RIMA = "rima"
 
 Log into the instance
 ```bash
-gcloud compute ssh username@{yourname}-{pipeline}-keyaddition
+gcloud compute ssh --tunnel-through-iap username@{yourname}-{pipeline}-keyaddition
 
 ```
 

--- a/docs/google-cloud/Running_Automator_part1.md
+++ b/docs/google-cloud/Running_Automator_part1.md
@@ -15,7 +15,7 @@ gcloud compute instances create {username}-automator-instance --machine-type n2-
 
 Upload your ~/.ssh/google_compute_engine key to the automator instance.
 ```bash
-gcloud compute scp ~/.ssh/google_cloud_engine <username>@{username}-automator-instance:~/.ssh/
+gcloud compute scp ~/.ssh/google_cloud_engine <username>@{username}-automator-instance:~/.ssh/ --tunnel-through-iap
 ```
 
 ## Step 2. The environment has already been added onto the automator VM image.  Activate it to check that is working:

--- a/docs/google-cloud/Running_Automator_part2_chips.md
+++ b/docs/google-cloud/Running_Automator_part2_chips.md
@@ -10,7 +10,7 @@ NOTE: These steps are completed on the automator instance created in Part 1.
 
 0. Log into your automator instance:
 ```bash
-gcloud compute ssh <username>@{username}-automator-instance:~/.ssh/
+gcloud compute ssh --tunnel-through-iap <username>@{username}-automator-instance:~/.ssh/
 ```
 
 
@@ -78,7 +78,7 @@ Parameters that are unique to each chips run, include the following:
     Users need to login to the instance to check on the runs.
         1. Log into the instance:
           ```bash
-          gcloud compute ssh  [username]@chips-auto-fast-test
+          gcloud compute ssh --tunnel-through-iap [username]@chips-auto-fast-test
           cd /mnt/ssd/chips
           ```
         2. run top:

--- a/docs/google-cloud/Running_Automator_part2_rima.md
+++ b/docs/google-cloud/Running_Automator_part2_rima.md
@@ -9,7 +9,7 @@ NOTE: These steps are completed on the automator instance created in Part 1.
 
 0. Log into your automator instance:
 ```bash
-gcloud compute ssh <username>@{username}-automator-instance:~/.ssh/
+gcloud compute ssh --tunnel-through-iap <username>@{username}-automator-instance:~/.ssh/
 ```
 
 
@@ -79,7 +79,7 @@ Parameters that are unique to each rima run, include the following:
     Users need to login to the instance to check on the runs.
         1. Log into the instance:
           ```bash
-          gcloud compute ssh [username]@rima-auto-fast-test
+          gcloud compute ssh --tunnel-through-iap [username]@rima-auto-fast-test
           cd /mnt/ssd/rima
           ```
 

--- a/docs/google-cloud/Running_Automator_part2_wes.md
+++ b/docs/google-cloud/Running_Automator_part2_wes.md
@@ -10,7 +10,7 @@ NOTE: These steps are completed on the automator instance created in Part 1.
 
 0. Log into your automator instance:
 ```bash
-gcloud compute ssh <username>@{username}-automator-instance:~/.ssh/
+gcloud compute ssh --tunnel-through-iap <username>@{username}-automator-instance:~/.ssh/
 ```
 
 1. Clone the wes_automator repository (if you don’t have a copy already):
@@ -83,7 +83,7 @@ Parameters that are unique to each wes run, include the following:
 
         1. Log into the instance:
           ```bash
-          gcloud compute ssh  [username]@wes-auto-fast-test
+          gcloud compute ssh --tunnel-through-iap [username]@wes-auto-fast-test
           cd /mnt/ssd/wes
           ```
 

--- a/docs/google-cloud/Running_Ingestion.md
+++ b/docs/google-cloud/Running_Ingestion.md
@@ -18,7 +18,7 @@ After the users have completed all the prerequisites, they can proceed to the ma
 
 (ii) Login to the GCP instance that stores the results from the runs.
   ```bash
-     gcloud compute ssh [username]@[instance_name]
+     gcloud compute ssh --tunnel-through-iap [username]@[instance_name]
   ```
 
 (iii) Transfer the ingestion spreadsheet provided by Jen to the instance.      
@@ -28,10 +28,10 @@ After the users have completed all the prerequisites, they can proceed to the ma
   ```
      Next, transfer the ingestion spreadsheet from local computer to the VM instance. To do so, go to your local terminal and use the gcloud scp command as mentioned below.
   ```bash
-     gcloud compute scp [ingestion_spreadsheet.xlsx] [username]@[instance_name]:/mnt/ssd
+     gcloud compute scp --tunnel-through-iap [ingestion_spreadsheet.xlsx] [username]@[instance_name]:/mnt/ssd
   ```
      e.g.
-     gcloud compute scp CNKA2Q88X.01_template.xlsx jen@wes-auto-cnka2q88x:/mnt/ssd/
+     gcloud compute scp --tunnel-through-iap CNKA2Q88X.01_template.xlsx jen@wes-auto-cnka2q88x:/mnt/ssd/
 
 (iv) CIDC-CIMAC portal has further instructions on how to proceed ahead with ingestion. .
   ```bash


### PR DESCRIPTION
Added --tunnel-through-iap to gcloud ssh and gcloud scp commands in the following documents:
- All Running_Automator*.md documents (part 0, part 1, part2_chips, etc)
- Running_Ingestion.md

Note -- the same commands need to be updated in other documents such as wes-gcp.md and creating a reference snapshot.  However, these documents also need other lines updated such as those referring to getting the external IP.